### PR TITLE
Be stricter with Deno permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Run**
 
 ```
- deno run --allow-net --allow-read --allow-write ./index.js
+ deno run --allow-net=:5000 --allow-read=./data/todos.json --allow-write=./data/todos.json ./index.js
 ```
 
 ## **`GET`** - /todos


### PR DESCRIPTION
Deno's `--allow-net --allow-read --allow-write` permissions are too broad for a demo app to showcase Deno's security.